### PR TITLE
Split dependencies between runtime and test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
 - '3.4'
-install: pip install -r requirements.txt
+install: pip install -r requirements.txt -r requirements-test.txt
 script: "./test.sh"
 notifications:
   slack:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,3 @@
+configobj
+mockito-without-hardcoded-distribute-version
+nose

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,4 @@ pyserial
 influxdb
 fs
 pyhamcrest
-mockito-without-hardcoded-distribute-version
-nose
-configobj
 val


### PR DESCRIPTION
Because inevitably you won't want half that stuff if you're running in a
constrained environment
