### PR TITLE
Explicit dependency version pinning

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,3 @@
-configobj
-mockito-without-hardcoded-distribute-version
-nose
+configobj==5.0.6
+mockito-without-hardcoded-distribute-version==0.5.4
+nose==1.3.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-simplejson
-pyserial
-influxdb
-fs
-pyhamcrest
-val
+PyHamcrest==1.8.5
+fs==0.5.4
+influxdb==2.12.0
+pyserial==3.0.1
+simplejson==3.8.1
+val==0.6


### PR DESCRIPTION
Nobody likes surprise test breakage because something updated

Explicit > Implicit
