### PR TITLE
*Actually* fix Travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-[![Build Status](https://travis-ci.org/BrewPi/connector.svg?branch=master)](https://travis-ci.org/BrewPi/connector)
+[![Build Status](https://travis-ci.org/BrewPi/connector.svg?branch=develop)](https://travis-ci.org/BrewPi/connector)


### PR DESCRIPTION
Looks like a TravisCI bug whereby their badge copypasta assumes your
default branch is named `master` (and this repo uses `develop` as a
base)
